### PR TITLE
mxnet-gluon example (with RDMA): create gluon data loader before initializing byteps

### DIFF
--- a/example/mxnet-gluon/train_mnist_byteps.py
+++ b/example/mxnet-gluon/train_mnist_byteps.py
@@ -97,15 +97,15 @@ def evaluate(model, data_iter, context):
     return metric.get()
 
 
+# Load training and validation data
+train_data, val_data, train_size = get_mnist_iterator()
+
 # Initialize BytePS
 bps.init()
 
 # BytePS: pin context to local rank
 context = mx.cpu(bps.local_rank()) if args.no_cuda else mx.gpu(bps.local_rank())
 num_workers = bps.size()
-
-# Load training and validation data
-train_data, val_data, train_size = get_mnist_iterator()
 
 # Build model
 model = conv_nets()


### PR DESCRIPTION
Following #54, the [mxnet-gluon example](https://github.com/bytedance/byteps/blob/master/example/mxnet-gluon/train_mnist_byteps.py) will crash (`server` crashes in RDMA layer) when `byteps` uses RDMA (`DMLC_ENABLE_RDMA=1`). 

The example initializes `byteps` (**with RDMA**), and then creates gluon data loader ([code](https://github.com/bytedance/byteps/blob/8dce68839cde5236a0bf908bc765d730df9c339d/example/mxnet-gluon/train_mnist_byteps.py#L100#L108)).
```python
# Initialize BytePS
bps.init()

# BytePS: pin context to local rank
context = mx.cpu(bps.local_rank()) if args.no_cuda else mx.gpu(bps.local_rank())
num_workers = bps.size()

# Load training and validation data
train_data, val_data, train_size = get_mnist_iterator()
```
As explained by @ymjiang in #54, the default (multi-process) gluon data loader forks from the RDMA process which may lead to unexpected errors ([reason](https://www.rdmamojo.com/2012/05/24/ibv_fork_init/)). Therefore, *one very simple solution is to create gluon data loader before `bps.init()`*, which is included in this PR.

Thank you.