### PR TITLE
Bug fixed: PyTorch distributed training stuck

### DIFF
--- a/byteps/torch/__init__.py
+++ b/byteps/torch/__init__.py
@@ -81,10 +81,10 @@ class _DistributedOptimizer(torch.optim.Optimizer):
             self._register_hooks()
 
         # declare tensors
-        for name in self._parameter_names.values():
+        for name in sorted(self._parameter_names.values()):
             declare("Gradient."+name)
         # We use two loops for load-balancing
-        for name in self._parameter_names.values():
+        for name in sorted(self._parameter_names.values()):
             declare("Parameter."+name)
 
     @staticmethod


### PR DESCRIPTION
Hi, 

I just found out that the BytePS distributed training in Pytorch will stuck at 
```c++
BytePSGlobal::GetPS()->Wait(BytePSGlobal::GetPS()->ZPush(pskv.keys, vals, pskv.lens, cmd));
```
<img width="1280" alt="Screen Shot 2019-09-12 at 5 05 55 PM" src="https://user-images.githubusercontent.com/14297310/64826520-909c3100-d586-11e9-96a4-e3278c1ce222.png">
<img width="1280" alt="Screen Shot 2019-09-12 at 5 06 01 PM" src="https://user-images.githubusercontent.com/14297310/64826521-909c3100-d586-11e9-883a-821623ae436c.png">

The problem was that the initialized Tensor that sending to the PS in different machines have different keys, then it stuck.

It is because the passing order of the Tensor declaration is not sorted. In `byteps/torch/__init__.py`, even `self._parameter_names` is already sorted but `self._parameter_names.values()` will return an unsorted order to BytePS. 


Thanks,
Lam