### PR TITLE
tf: enable async training

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ BytePS outperforms existing open-sourced distributed training frameworks by a la
 - Find your training stragglers using [server timeline](docs/timeline.md)
 - [Improved key distribution strategy for better load-balancing](https://github.com/bytedance/byteps/pull/116) 
 - [Improved RDMA robustness](https://github.com/bytedance/byteps/pull/91)
-- [Asynchronous training support for MXNet](https://github.com/bytedance/byteps/pull/114)
+- Asynchronous training support for
+[PyTorch](https://github.com/bytedance/byteps/pull/121), 
+[TensorFlow](https://github.com/bytedance/byteps/pull/122), 
+[MXNet](https://github.com/bytedance/byteps/pull/114)
 
 ## Performance
 

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -214,24 +214,38 @@ class DistributedOptimizer(tf.train.Optimizer):
         only supports async training based on minimize(). We do not support
         the case where a user calls compute_gradients and apply_gradients explicitly.
         """
-        grads_and_vars = compute_gradients(
-            loss, var_list=var_list, gate_gradients=gate_gradients,
-            aggregation_method=aggregation_method,
-            colocate_gradients_with_ops=colocate_gradients_with_ops,
-            grad_loss=grad_loss)
-
-        vars_with_grad = [v for g, v in grads_and_vars if g is not None]
-        if not vars_with_grad:
-            raise ValueError(
-                "No gradients provided for any variable, check your graph for ops"
-                " that do not support gradients, between variables %s and loss %s." %
-                ([str(v) for _, v in grads_and_vars], loss))
-
         if not self._enable_async:
+            grads_and_vars = compute_gradients(loss, var_list=var_list,
+                                               gate_gradients=gate_gradients,
+                                               aggregation_method=aggregation_method,
+                                               colocate_gradients_with_ops=colocate_gradients_with_ops,
+                                               grad_loss=grad_loss)
+
+            vars_with_grad = [v for g, v in grads_and_vars if g is not None]
+            if not vars_with_grad:
+                raise ValueError(
+                    "No gradients provided for any variable, check your graph for ops"
+                    " that do not support gradients, between variables %s and loss %s." %
+                    ([str(v) for _, v in grads_and_vars], loss))
+
             return self._optimizer.apply_gradients(grads_and_vars,
                                                    global_step=global_step,
                                                    name=name)
         else: # asynchronous training
+            grads_and_vars = self._optimizer.compute_gradients(
+                                                loss, var_list=var_list,
+                                                gate_gradients=gate_gradients,
+                                                aggregation_method=aggregation_method,
+                                                colocate_gradients_with_ops=colocate_gradients_with_ops,
+                                                grad_loss=grad_loss)
+
+            vars_with_grad = [v for g, v in grads_and_vars if g is not None]
+            if not vars_with_grad:
+                raise ValueError(
+                    "No gradients provided for any variable, check your graph for ops"
+                    " that do not support gradients, between variables %s and loss %s." %
+                    ([str(v) for _, v in grads_and_vars], loss))
+
             grads, vars = zip(*grads_and_vars)
             old_vars = []
             for var in vars:

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -260,7 +260,6 @@ class DistributedOptimizer(tf.train.Optimizer):
             apply_ops = self._optimizer.apply_gradients(grads_and_vars,
                                                         global_step=global_step,
                                                         name=name)
-            assign_op_list = []
             with tf.control_dependencies([apply_ops]):
                 # get the delta
                 for i, var in enumerate(vars):
@@ -270,13 +269,14 @@ class DistributedOptimizer(tf.train.Optimizer):
                 updated_tensors = self._push_pull_grads(old_tensors)
 
                 # copy the updated variable back
+                assign_op_list = []
                 for i, tensor in enumerate(updated_tensors):
                     assign_op_list.append(tf.assign(vars[i], tensor))
 
-            with tf.control_dependencies([assign_op_list]):
-                dump_op = tf.identity(apply_ops)
+                with tf.control_dependencies(assign_op_list):
+                    dump_op = tf.identity(apply_ops)
 
-            return dump_op
+                return dump_op
 
     def get_slot(self, *args, **kwargs):
         """Calls this same method on the underlying optimizer."""

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -274,7 +274,7 @@ class DistributedOptimizer(tf.train.Optimizer):
                     assign_op_list.append(tf.assign(vars[i], tensor))
 
             with tf.control_dependencies([assign_op_list]):
-                dump_op = tf.identity(assign_op_list)
+                dump_op = tf.identity(apply_ops)
 
             return dump_op
 

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -27,6 +27,7 @@ from byteps.tensorflow.ops import size, local_size, rank, local_rank
 from byteps.tensorflow.util import _executing_eagerly
 
 import tensorflow as tf
+import os
 
 
 def push_pull(tensor, scope='', average=True, device_dense='', device_sparse='',

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -261,9 +261,9 @@ class DistributedOptimizer(tf.train.Optimizer):
                                                         global_step=global_step,
                                                         name=name)
             with tf.control_dependencies([apply_ops]):
-                # get the delta parameter
+                # get the delta
                 for i, var in enumerate(vars):
-                    old_tensors[i] = var - old_tensors[i]
+                    old_tensors[i] = tf.subtract(var, old_tensors[i])
 
                 # reuse the _push_pul_grads(), but is transferring parameters
                 updated_tensors = self._push_pull_grads(old_tensors)

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -28,7 +28,7 @@ from byteps.tensorflow.util import _executing_eagerly
 
 import tensorflow as tf
 import os, sys
-
+from tensorflow.python.ops import control_flow_ops
 
 def push_pull(tensor, scope='', average=True, device_dense='', device_sparse='',
               compression=Compression.none, enable_async=False):
@@ -273,10 +273,9 @@ class DistributedOptimizer(tf.train.Optimizer):
                 for i, tensor in enumerate(updated_tensors):
                     assign_op_list.append(tf.assign(vars[i], tensor))
 
-                with tf.control_dependencies(assign_op_list):
-                    dump_op = tf.identity(apply_ops)
+            dump_op = control_flow_ops.group(*assign_op_list)
 
-                return dump_op
+            return dump_op
 
     def get_slot(self, *args, **kwargs):
         """Calls this same method on the underlying optimizer."""

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -206,17 +206,18 @@ class DistributedOptimizer(tf.train.Optimizer):
         return self._optimizer.apply_gradients(*args, **kwargs)
 
     def minimize(self, loss, global_step=None, var_list=None,
-               gate_gradients=GATE_OP, aggregation_method=None,
-               colocate_gradients_with_ops=False, name=None,
-               grad_loss=None):
+                 gate_gradients=tf.train.Optimizer.GATE_OP,
+                 aggregation_method=None,
+                 colocate_gradients_with_ops=False, 
+                 name=None, grad_loss=None):
         """Override this function for async training.
         BytePS currently only supports async training based on minimize().
         """
-        grads_and_vars = self._optimizer.compute_gradients(loss, var_list=var_list,
-                            gate_gradients=gate_gradients,
-                            aggregation_method=aggregation_method,
-                            colocate_gradients_with_ops=colocate_gradients_with_ops,
-                            grad_loss=grad_loss)
+        grads_and_vars = self._optimizer.compute_gradients(
+            loss, var_list=var_list, gate_gradients=gate_gradients,
+            aggregation_method=aggregation_method,
+            colocate_gradients_with_ops=colocate_gradients_with_ops,
+            grad_loss=grad_loss)
 
         vars_with_grad = [v for g, v in grads_and_vars if g is not None]
         if not vars_with_grad:
@@ -235,8 +236,8 @@ class DistributedOptimizer(tf.train.Optimizer):
             for var in vars:
                 old_vars.append(tf.Variable(var))
             apply_ops = self._optimizer.apply_gradients(grads_and_vars,
-                                                   global_step=global_step,
-                                                   name=name)
+                                                        global_step=global_step,
+                                                        name=name)
             for i, var in enumerate(vars):
                 tf.assign_sub(var, old_vars[i])
             updated_vars = self._push_pull_grads(vars)

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -214,7 +214,7 @@ class DistributedOptimizer(tf.train.Optimizer):
         only supports async training based on minimize(). We do not support
         the case where a user calls compute_gradients and apply_gradients explicitly.
         """
-        grads_and_vars = self._optimizer.compute_gradients(
+        grads_and_vars = compute_gradients(
             loss, var_list=var_list, gate_gradients=gate_gradients,
             aggregation_method=aggregation_method,
             colocate_gradients_with_ops=colocate_gradients_with_ops,

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -205,11 +205,18 @@ class DistributedOptimizer(tf.train.Optimizer):
         """Calls this same method on the underlying optimizer."""
         return self._optimizer.apply_gradients(*args, **kwargs)
 
-    def minimize(self, *args, **kwargs):
+    def minimize(self, loss, global_step=None, var_list=None,
+               gate_gradients=GATE_OP, aggregation_method=None,
+               colocate_gradients_with_ops=False, name=None,
+               grad_loss=None):
         """Override this function for async training.
         BytePS currently only supports async training based on minimize().
         """
-        grads_and_vars = self._optimizer.compute_gradients(*args, **kwargs)
+        grads_and_vars = self._optimizer.compute_gradients(loss, var_list=var_list,
+                            gate_gradients=gate_gradients,
+                            aggregation_method=aggregation_method,
+                            colocate_gradients_with_ops=colocate_gradients_with_ops,
+                            grad_loss=grad_loss)
 
         vars_with_grad = [v for g, v in grads_and_vars if g is not None]
         if not vars_with_grad:
@@ -219,13 +226,17 @@ class DistributedOptimizer(tf.train.Optimizer):
                 ([str(v) for _, v in grads_and_vars], loss))
 
         if not self._enable_async:
-            return self._optimizer.apply_gradients(*args, **kwargs)
+            return self._optimizer.apply_gradients(grads_and_vars,
+                                                   global_step=global_step,
+                                                   name=name)
         else: # asynchronous training
             grads, vars = zip(*grads_and_vars)
             old_vars = []
             for var in vars:
                 old_vars.append(tf.Variable(var))
-            apply_ops = self._optimizer.apply_gradients(*args, **kwargs)
+            apply_ops = self._optimizer.apply_gradients(grads_and_vars,
+                                                   global_step=global_step,
+                                                   name=name)
             for i, var in enumerate(vars):
                 tf.assign_sub(var, old_vars[i])
             updated_vars = self._push_pull_grads(vars)

--- a/byteps/tensorflow/ops.py
+++ b/byteps/tensorflow/ops.py
@@ -24,7 +24,6 @@ import re
 import os
 import ctypes
 
-import tensorflow as tf
 from tensorflow.python.framework import load_library
 from tensorflow.python.framework import ops
 from tensorflow.python.platform import resource_loader
@@ -32,6 +31,7 @@ from tensorflow.python.platform import resource_loader
 from byteps.common import get_ext_suffix
 from byteps.common import BytePSBasics as _BytePSBasics
 from byteps.tensorflow.util import _executing_eagerly
+import tensorflow as tf
 
 
 def _load_library(name):

--- a/docs/env.md
+++ b/docs/env.md
@@ -118,3 +118,12 @@ Increasing the number of engine CPU threads may also improves server performance
 ```
 export MXNET_CPU_WORKER_NTHREADS=p
 ```
+
+## Asynchronous training
+
+Enable asynchronous training with (on all workers and servers)
+
+```
+export BYTEPS_ENABLE_ASYNC=1
+```
+

--- a/example/tensorflow/run_tensorflow_byteps.sh
+++ b/example/tensorflow/run_tensorflow_byteps.sh
@@ -4,10 +4,10 @@ path="`dirname $0`"
 
 if [ "$EVAL_TYPE" == "benchmark" ]; then
   echo "Run synthetic benchmark..."
-  python $path/synthetic_benchmark.py $@
+  python3 $path/synthetic_benchmark.py $@
 elif [ "$EVAL_TYPE" == "mnist" ]; then
   echo "Run MNIST ..."
-  python $path/tensorflow_mnist.py $@
+  python3 $path/tensorflow_mnist.py $@
 else
   echo "Error: unsupported $EVAL_TYPE"
   exit 1

--- a/example/tensorflow/synthetic_benchmark.py
+++ b/example/tensorflow/synthetic_benchmark.py
@@ -2,13 +2,13 @@
 from __future__ import absolute_import, division, print_function
 
 import argparse
-import os
+import os, sys
 import numpy as np
 import timeit
 
-import tensorflow as tf
 import byteps.tensorflow as bps
 from tensorflow.keras import applications
+import tensorflow as tf
 
 # Benchmark settings
 parser = argparse.ArgumentParser(description='TensorFlow Synthetic Benchmark',
@@ -79,7 +79,7 @@ def log(s, nl=True):
     if bps.rank() != 0:
         return
     print(s, end='\n' if nl else '')
-
+    sys.stdout.flush()
 
 log('Model: %s' % args.model)
 log('Batch size: %d' % args.batch_size)

--- a/example/tensorflow/tensorflow_mnist.py
+++ b/example/tensorflow/tensorflow_mnist.py
@@ -15,11 +15,11 @@
 
 import os
 import errno
-import tensorflow as tf
 import byteps.tensorflow as bps
 import numpy as np
 
 from tensorflow import keras
+import tensorflow as tf
 
 layers = tf.layers
 


### PR DESCRIPTION
Asynchronous training implementation for TensorFlow. Similar to https://github.com/bytedance/byteps/pull/114 (MXNet) and https://github.com/bytedance/byteps/pull/121 (PyTorch). 

Usage: `export BYTEPS_ENABLE_ASYNC=1`