### PR TITLE
common: add multiple key hash functions

### DIFF
--- a/byteps/common/global.cc
+++ b/byteps/common/global.cc
@@ -331,8 +331,9 @@ uint64_t BytePSGlobal::Hash_DJB2(uint64_t key) {
   auto str = std::to_string(key).c_str();
   uint64_t hash = 5381;
   int c;
-  while (c = *str++) { // hash(i) = hash(i-1) * 33 ^ str[i]
+  while (c = *str) { // hash(i) = hash(i-1) * 33 ^ str[i]
     hash = ((hash << 5) + hash) + c; 
+    str++;
   }
   return hash;
 }
@@ -341,8 +342,9 @@ uint64_t BytePSGlobal::Hash_SDBM(uint64_t key) {
   auto str = std::to_string(key).c_str();
   uint64_t hash = 0;
   int c;
-  while (c = *str++) { // hash(i) = hash(i-1) * 65599 + str[i]
+  while (c = *str) { // hash(i) = hash(i-1) * 65599 + str[i]
     hash = c + (hash << 6) + (hash << 16) - hash;
+    str++;
   }
   return hash;
 }
@@ -362,14 +364,14 @@ PSKV& BytePSGlobal::EncodeDefaultKey(uint64_t key, size_t len) {
     if (!_hash_knob.compare(std::string("naive"))) {
       server = Hash_Naive(key) % num_servers;
     } else if (!_hash_knob.compare(std::string("built_in"))) {
-        server = Hash_BuiltIn(key) % num_servers;
+      server = Hash_BuiltIn(key) % num_servers;
     } else if (!_hash_knob.compare(std::string("djb2"))) {
-        server = Hash_DJB2(key) % num_servers;
+      server = Hash_DJB2(key) % num_servers;
     } else if (!_hash_knob.compare(std::string("sdbm"))) {
-        server = Hash_SDBM(key) % num_servers;
+      server = Hash_SDBM(key) % num_servers;
     } else {
-        BPS_CHECK(0) << "Unsupported BYTEPS_KEY_HASH_FN, "
-                     << "must be one of [naive, built_in, djb2, sdbm]";
+      BPS_CHECK(0) << "Unsupported BYTEPS_KEY_HASH_FN, "
+                   << "must be one of [naive, built_in, djb2, sdbm]";
     }
     
     _server_accumulated_len[server] += len;

--- a/byteps/common/global.cc
+++ b/byteps/common/global.cc
@@ -331,7 +331,7 @@ uint64_t BytePSGlobal::Hash_Naive(uint64_t key) {
 }
 uint64_t BytePSGlobal::Hash_BuiltIn(uint64_t key) {
   auto str = std::to_string(key).c_str();
-  return _built_in_hash_fn(str);
+  return _built_in_hash_fn(str) * _built_in_hash_coefficient;
 }
 
 uint64_t BytePSGlobal::Hash_DJB2(uint64_t key) {

--- a/byteps/common/global.h
+++ b/byteps/common/global.h
@@ -84,8 +84,7 @@ class BytePSGlobal {
   static BPSContext& GetContextFromName(const std::string& name);
   static uint32_t GetTensorCount();
 
-  static bool _use_hash;
-  static std::hash<ps::Key> _hash_fn;
+  static std::hash<ps::Key> _built_in_hash_fn;
   static std::vector<unsigned long> _server_accumulated_len;
   static std::unordered_map<uint64_t, PSKV> ps_kv_;
   static PSKV& EncodeDefaultKey(uint64_t key, size_t len);
@@ -164,6 +163,13 @@ class BytePSGlobal {
   static int AlignTo(int input, int alignment) {
     return input / alignment * alignment;
   }
+  
+  // hash functions
+  static std::string _hash_knob;
+  static uint64_t Hash_Naive(uint64_t key);
+  static uint64_t Hash_BuiltIn(uint64_t key);
+  static uint64_t Hash_DJB2(uint64_t key);
+  static uint64_t Hash_SDBM(uint64_t key);
 };
 
 }  // namespace common

--- a/byteps/common/global.h
+++ b/byteps/common/global.h
@@ -84,7 +84,6 @@ class BytePSGlobal {
   static BPSContext& GetContextFromName(const std::string& name);
   static uint32_t GetTensorCount();
 
-  static std::hash<ps::Key> _built_in_hash_fn;
   static std::vector<unsigned long> _server_accumulated_len;
   static std::unordered_map<uint64_t, PSKV> ps_kv_;
   static PSKV& EncodeDefaultKey(uint64_t key, size_t len);
@@ -166,6 +165,8 @@ class BytePSGlobal {
   
   // hash functions
   static std::string _hash_knob;
+  static std::hash<std::string> _built_in_hash_fn;
+  static unsigned int _built_in_hash_coefficient;
   static uint64_t Hash_Naive(uint64_t key);
   static uint64_t Hash_BuiltIn(uint64_t key);
   static uint64_t Hash_DJB2(uint64_t key);


### PR DESCRIPTION
Improve the built in hash function, and add two advanced hash functions `DJB2` and `SDBM` ([reference](http://www.cse.yorku.ca/~oz/hash.html)). Use `BYTEPS_KEY_HASH_FN` to choose one of them.

Use `DJB2` as the default. For example, on Gluon-BERT training, the hash result is:
(`naive` and `built_in` perform bad in the same case)
```
2 servers
server 0, accumulated workload for this server is 671807488
server 1, accumulated workload for this server is 668825212

4 servers
server 0, accumulated workload for this server is 302258180
server 1, accumulated workload for this server is 342281848
server 2, accumulated workload for this server is 373814900
server 3, accumulated workload for this server is 326547460

8 servers
server 0, accumulated workload for this server is 146038784
server 1, accumulated workload for this server is 170022912
server 2, accumulated workload for this server is 197044224
server 3, accumulated workload for this server is 173389824
server 4, accumulated workload for this server is 152020992
server 5, accumulated workload for this server is 172256888
server 6, accumulated workload for this server is 172607488
server 6, accumulated workload for this server is 176703488
server 7, accumulated workload for this server is 153155588
```

