### PR TITLE
mxnet: Use C_API for creating NDArray and Context 

### DIFF
--- a/byteps/mxnet/ops.cc
+++ b/byteps/mxnet/ops.cc
@@ -28,7 +28,7 @@ namespace mxnet {
 namespace {
 
 std::atomic_int op_count;
-const auto MX_EXEC_CTX = Context::CPU();
+const auto MX_EXEC_CTX = Context();
 const auto MX_FUNC_PROP = FnProperty::kCPUPrioritized;
 
 // struct to hold parameters for pushpull with MXNet Engine

--- a/byteps/mxnet/tensor_util.cc
+++ b/byteps/mxnet/tensor_util.cc
@@ -122,14 +122,14 @@ int TensorUtil::GetDevice(NDArray* tensor) {
 // If dev_id equal to CPU_DEVICE_ID, construct Tensor on CPU
 // Otherwise construct on GPU
 NDArray* TensorUtil::New(int device, int dtype) {
+  NDArrayHandle array;
+  int dev_type = gpu::kDevMask;
   if (device == CPU_DEVICE_ID) {
-    NDArray* my_array = new NDArray(TShape(), Context::CPU(0), false, dtype);
-    return my_array;
-  } else {
-    NDArray* my_array =
-        new NDArray(TShape(), Context::GPU(device), false, dtype);
-    return my_array;
+    dev_type = cpu::kDevMask;
+    device = 0;
   }
+  MXNDArrayCreateEx(nullptr, 0, dev_type, device, true, dtype, &array);
+  return static_cast<NDArray*>(array);
 }
 
 void TensorUtil::Free(NDArray* tensor) { delete tensor; }


### PR DESCRIPTION
A few symbols are not exported in the latest nightly version of MXNet, which breaks byteps. Related thread: https://github.com/apache/incubator-mxnet/pull/15591 and https://github.com/bytedance/byteps/issues/173 

This PR replaces context creation and ndarray creation with c_apis to avoid the issue. 