### PR TITLE
mxnet: fix the reording issue with gluon

### DIFF
--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -187,7 +187,11 @@ class DistributedTrainer(mx.gluon.Trainer):
 
     def _init_params(self):
         tensors = []
+        named_params = {}
         for param in self._params_to_init:
+            named_params[param.name] = param
+        for param_name in sorted(named_params.keys()):
+            param = named_params[param_name]
             if param._deferred_init:
                 tensors.append(param)
             else:


### PR DESCRIPTION
This patch ensures that the parameter declaration order is consistent across all ranks. However, self._param2idx may still be different, and it is not managed by BytePS. Fortunately, this patch can fix the broadcast reordering issue even without fixing self._param2idx