### PR TITLE
common: colocate and non-colocate mixed mode

### DIFF
--- a/byteps/common/global.cc
+++ b/byteps/common/global.cc
@@ -475,7 +475,7 @@ uint64_t BytePSGlobal::Hash_Mixed_PS_Allreduce(uint64_t key) {
   size_t num_server_noncolocate = num_server_total-num_worker_total;
   size_t num_server_colocate = num_worker_total;
 
-  auto bound = getenv("BYTEPS_MAGIC_PRIME_NUMBER") ? atoi(getenv("BYTEPS_MAGIC_PRIME_NUMBER")) : 997;
+  auto bound = getenv("BYTEPS_MIXED_MODE_BOUND") ? atoi(getenv("BYTEPS_MIXED_MODE_BOUND")) : 9973;
   BPS_CHECK_GE(bound, 100); // simple check to make sure the bound is sufficiently large
   auto ratio = (2.0 * num_server_noncolocate * (num_worker_total - 1)) / 
                   ((num_worker_total) * (num_worker_total+num_server_noncolocate) - 2 * num_server_noncolocate);
@@ -543,7 +543,7 @@ PSKV& BytePSGlobal::EncodeDefaultKey(uint64_t key, size_t len) {
       server = Hash_SDBM(key) % num_servers;
     } else if (!_hash_knob.compare(std::string("mixed"))) {
       BPS_CHECK(_mixed_mode) 
-          << "mixed mode should set BYTEPS_ENABLE_MIXED_PS_ALLREDUCE";
+          << "mixed mode should also set: BYTEPS_ENABLE_MIXED_PS_ALLREDUCE";
       server = Hash_Mixed_PS_Allreduce(key);
       CHECK_LT(server, num_servers);
     } else {

--- a/byteps/common/global.cc
+++ b/byteps/common/global.cc
@@ -479,7 +479,9 @@ uint64_t BytePSGlobal::Hash_Mixed_Mode(uint64_t key) {
   BPS_CHECK_GE(bound, 100); // simple check to make sure the bound is sufficiently large
   auto ratio = (2.0 * num_server_noncolocate * (num_worker_total - 1)) / 
                   ((num_worker_total) * (num_worker_total+num_server_noncolocate) - 2 * num_server_noncolocate);
-  BPS_CHECK_LE(ratio, 1);
+  BPS_CHECK_LE(ratio, 1) 
+      << "number of (non-colocate servers) > number of (worker)" 
+      << ", which is not permitted in the mixed mode";
   BPS_CHECK_GE(ratio, 0);
   auto threshold = ratio * bound;
 

--- a/byteps/common/global.cc
+++ b/byteps/common/global.cc
@@ -476,8 +476,11 @@ uint64_t BytePSGlobal::Hash_Mixed_Mode(uint64_t key) {
   size_t num_server_noncolocate = num_server_total-num_worker_total;
   size_t num_server_colocate = num_worker_total;
 
-  auto bound = getenv("BYTEPS_MIXED_MODE_BOUND") ? atoi(getenv("BYTEPS_MIXED_MODE_BOUND")) : 9973;
-  BPS_CHECK_GE(bound, num_server_total); // simple check to make sure the bound is sufficiently large
+  // The bound should be larger than num_server_total 
+  // in order to cover each server, but it also 
+  // cannot be too large because it might cause unbalance
+  auto bound = getenv("BYTEPS_MIXED_MODE_BOUND") ? atoi(getenv("BYTEPS_MIXED_MODE_BOUND")) : 101;
+  BPS_CHECK_GE(bound, num_server_total); 
   auto ratio = (2.0 * num_server_noncolocate * (num_worker_total - 1)) / 
                   ((num_worker_total) * (num_worker_total+num_server_noncolocate) - 2 * num_server_noncolocate);
   BPS_CHECK_LE(ratio, 1) 

--- a/byteps/common/global.h
+++ b/byteps/common/global.h
@@ -195,11 +195,12 @@ class BytePSGlobal {
   static std::string _hash_knob;
   static std::hash<std::string> _built_in_hash_fn;
   static unsigned int _built_in_hash_coefficient;
+  static volatile bool _mixed_mode;
   static uint64_t Hash_Naive(uint64_t key);
   static uint64_t Hash_BuiltIn(uint64_t key);
   static uint64_t Hash_DJB2(uint64_t key);
   static uint64_t Hash_SDBM(uint64_t key);
-
+  static uint64_t Hash_Mixed_PS_Allreduce(uint64_t key);
 };
 
 }  // namespace common

--- a/byteps/common/global.h
+++ b/byteps/common/global.h
@@ -200,7 +200,7 @@ class BytePSGlobal {
   static uint64_t Hash_BuiltIn(uint64_t key);
   static uint64_t Hash_DJB2(uint64_t key);
   static uint64_t Hash_SDBM(uint64_t key);
-  static uint64_t Hash_Mixed_PS_Allreduce(uint64_t key);
+  static uint64_t Hash_Mixed_Mode(uint64_t key);
 };
 
 }  // namespace common

--- a/byteps/common/global.h
+++ b/byteps/common/global.h
@@ -87,6 +87,7 @@ class BytePSGlobal {
   static uint32_t GetTensorCount();
 
   static std::vector<unsigned long> _server_accumulated_len;
+  static unsigned long _total_accumulated_len;
   static std::unordered_map<uint64_t, PSKV> ps_kv_;
   static PSKV& EncodeDefaultKey(uint64_t key, size_t len);
 


### PR DESCRIPTION
Usage:
`export BYTEPS_ENABLE_MIXED_MODE=1` for scheduler and workers.