### PR TITLE
mxnet: rm wait_to_read

### DIFF
--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -225,6 +225,5 @@ class DistributedTrainer(mx.gluon.Trainer):
                     param_arrays[0].__imul__(0)
                 byteps_push_pull(param_arrays[0], version=0, priority=0,
                                  name="parameter_" + str(idx), is_average=False)
-                param_arrays[0].wait_to_read()
 
         self._params_to_init = tensors


### PR DESCRIPTION
BytePS assumes that the tensor it takes will not be freed during pushpull. This holds true in current situations where params or grads are always kept in _ParameterDict_. But when taking a temporary tensor as input, the tensor may be freed in the python thread but BytePS does not know that due to MXNet's asynchronous execution, which leads to a crash in BytePS. 

This problem has been fix in horovod. see 
https://github.com/horovod/horovod/pull/1639
https://github.com/horovod/horovod/pull/1718

By storing a shallow copy of the tensor in `PushPullParam`, its lifecycle will expand to pushpull operation ending. 