### PR TITLE
build: update setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include */* LICENSE byteps.lds byteps.exp
 exclude .git/*
 recursive-include * *.cc *.h
 graft 3rdparty/ps-lite
+include ./pre_setup.py

--- a/pre_setup.py
+++ b/pre_setup.py
@@ -1,0 +1,7 @@
+# For internal use. Please do not modify this file.
+
+def setup():
+    return
+
+def extra_make_option():
+    return ""


### PR DESCRIPTION
add two optional environment variables:
BYTEPS_PRE_SETUP_SCRIPT
    shell commands to run. e.g. BYTEPS_PRE_SETUP_SCRIPT="yum install -y gcc"
    intalls gcc.

BYTEPS_EXTRA_MAKE_OPTION
    additional options to pass to make when installing third party
    dependencies.

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>