### PR TITLE
torch: forbid using skip_synchronize in async training

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -942,12 +942,13 @@ setup(
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
+        'License :: OSI Approved :: Apache Software License'
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
+        'Operating System :: POSIX :: Linux'
     ],
     ext_modules=[server_lib, tensorflow_lib, mxnet_lib, pytorch_lib],
     # $ setup.py publish support.


### PR DESCRIPTION
After optimizer.skip_synchronization() is called, optimizer.step()
returns after triggering push-pull. Otherwise the local gradients from
the current pass will be lost.

Fix license classifier.
Add OS classifier.