### PR TITLE
setup: fix mxnet-mkl segmentation fault

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -684,9 +684,9 @@ def build_mx_extension(build_ext, options):
     else:
         mxnet_lib.define_macros += [('MSHADOW_USE_CUDA', '0')]
     if is_mx_mkldnn():
-        mxnet_mpi_lib.define_macros += [('MXNET_USE_MKLDNN', '1')]
+        mxnet_lib.define_macros += [('MXNET_USE_MKLDNN', '1')]
     else:
-        mxnet_mpi_lib.define_macros += [('MXNET_USE_MKLDNN', '0')]  
+        mxnet_lib.define_macros += [('MXNET_USE_MKLDNN', '0')]  
     mxnet_lib.define_macros += [('MSHADOW_USE_MKL', '0')]
 
     # use MXNet's DMLC headers first instead of ps-lite's

--- a/setup.py
+++ b/setup.py
@@ -648,7 +648,7 @@ def is_mx_mkldnn():
                     output = subprocess.check_output(['readelf', '-d', mx_lib])
                     if 'mkldnn' in str(output):
                         return True
-                    return False
+                return False
             except Exception:
                 print(msg)
                 return os.environ.get('MXNET_USE_MKLDNN', '0') == '1'

--- a/setup.py
+++ b/setup.py
@@ -515,8 +515,12 @@ def get_mx_flags(build_ext, cpp_flags):
     mx_libs = get_mx_libs(build_ext, mx_lib_dirs, cpp_flags)
 
     compile_flags = []
+    has_mkldnn = is_mx_mkldnn()
     for include_dir in mx_include_dirs:
         compile_flags.append('-I%s' % include_dir)
+        if has_mkldnn:
+            mkldnn_include = os.path.join(include_dir, 'mkldnn')
+            compile_flags.append('-I%s' % mkldnn_include)
 
     link_flags = []
     for lib_dir in mx_lib_dirs:
@@ -622,6 +626,33 @@ def get_nccl_vals():
 
     return nccl_include_dirs, nccl_lib_dirs, nccl_libs
 
+def is_mx_mkldnn():
+    try:
+        from mxnet import runtime
+        features = runtime.Features()
+        return features.is_enabled('MKLDNN')
+    except Exception:
+        msg = 'INFO: Cannot detect if MKLDNN is enabled in MXNet. Please \
+            set MXNET_USE_MKLDNN=1 if MKLDNN is enabled in your MXNet build.'
+        if 'linux' not in sys.platform:
+            # MKLDNN is only enabled by default in MXNet Linux build. Return 
+            # False by default for non-linux build but still allow users to 
+            # enable it by using MXNET_USE_MKLDNN env variable. 
+            print(msg)
+            return os.environ.get('MXNET_USE_MKLDNN', '0') == '1'
+        else:
+            try:
+                import mxnet as mx
+                mx_libs = mx.libinfo.find_lib_path()
+                for mx_lib in mx_libs:
+                    output = subprocess.check_output(['readelf', '-d', mx_lib])
+                    if 'mkldnn' in str(output):
+                        return True
+                    return False
+            except Exception:
+                print(msg)
+                return os.environ.get('MXNET_USE_MKLDNN', '0') == '1'
+
 
 def build_mx_extension(build_ext, options):
     # clear ROLE -- installation does not need this
@@ -652,6 +683,10 @@ def build_mx_extension(build_ext, options):
         mxnet_lib.define_macros += [('MSHADOW_USE_CUDA', '1')]
     else:
         mxnet_lib.define_macros += [('MSHADOW_USE_CUDA', '0')]
+    if is_mx_mkldnn():
+        mxnet_mpi_lib.define_macros += [('MXNET_USE_MKLDNN', '1')]
+    else:
+        mxnet_mpi_lib.define_macros += [('MXNET_USE_MKLDNN', '0')]  
     mxnet_lib.define_macros += [('MSHADOW_USE_MKL', '0')]
 
     # use MXNet's DMLC headers first instead of ps-lite's


### PR DESCRIPTION
Address https://github.com/bytedance/byteps/issues/222 and https://github.com/apache/incubator-mxnet/issues/18014. In short, the problem is that BytePS will run into segfault if using `mxnet-cu100mkl`.

Tested it with mxnet-cu100mkl==1.5.0. 