### PR TITLE
server: fix server improper free

### DIFF
--- a/byteps/server/server.cc
+++ b/byteps/server/server.cc
@@ -405,10 +405,14 @@ extern "C" void byteps_server() {
   msg.ops = TERMINATE;
   for (auto q : engine_queues_) q->Push(msg);
   for (auto t : engine_threads_) t->join();
-  for (auto& it : store_) free(it.second.tensor);
-  for (auto& it : update_buf_) free(it.second.merged.tensor);
-  LOG(INFO) << "byteps has been shutdown";
 
+  for (auto& it : store_) {
+    if (it.second.tensor) {
+      free(it.second.tensor);
+    }
+  }
+  
+  LOG(INFO) << "byteps has been shutdown";
   return;
 }
 


### PR DESCRIPTION
Attempt to fix https://github.com/bytedance/byteps/issues/279. Actually update_buf_ does not need to be freed (all its buffers are managed by ps-lite).