### PR TITLE
fix distributed initialization

### DIFF
--- a/byteps/mxnet/__init__.py
+++ b/byteps/mxnet/__init__.py
@@ -221,8 +221,6 @@ class DistributedTrainer(mx.gluon.Trainer):
                 param_arrays = param._check_and_get(param._data, list)
                 idx = self._param2idx[param.name]
 
-                if rank() != self.root_rank:
-                    param_arrays[0].__imul__(0)
                 byteps_push_pull(param_arrays[0], version=0, priority=0,
                                  name="parameter_" + str(idx), is_average=False)
 


### PR DESCRIPTION
According to this line https://github.com/bytedance/byteps/blob/master/byteps/server/server.cc#L197, the server will initialize the stored parameter from the last init push which could be sent from an arbitrary worker.
cc @eric-haibin-lin 