### PR TITLE
launcher: launching single-worker

### DIFF
--- a/launcher/launch.py
+++ b/launcher/launch.py
@@ -205,7 +205,8 @@ def launch_bps():
         for i in range(local_size):
             t[i].join()
 
-    else:
+    elif os.environ.get("BYTEPS_FORCE_DISTRIBUTED", "") == "1" or \
+         int(os.environ.get("DMLC_NUM_WORKER", "1")) > 1:
         import byteps.server
 
 


### PR DESCRIPTION
Do not launch server or scheduler when there's only one worker. To
launch server and scheduler anyway, do this:

  export BYTEPS_FORCE_DISTRIBUTED=1

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>