### PR TITLE
example: Update synthetic_benchmark_tf2.py

### DIFF
--- a/example/tensorflow/synthetic_benchmark_tf2.py
+++ b/example/tensorflow/synthetic_benchmark_tf2.py
@@ -50,7 +50,7 @@ model = getattr(applications, args.model)(weights=None)
 opt = tf.optimizers.SGD(0.01)
 
 data = tf.random.uniform([args.batch_size, 224, 224, 3])
-target = tf.random.uniform([args.batch_size, 1], minval=0, maxval=999, dtype=tf.int64)
+target = tf.random.uniform([args.batch_size, 1], minval=0, maxval=999, dtype=tf.float64)
 
 
 @tf.function
@@ -61,7 +61,7 @@ def benchmark_step(first_batch):
     # BytePS: use DistributedGradientTape
     with tf.GradientTape() as tape:
         probs = model(data, training=True)
-        loss = tf.losses.categorical_crossentropy(target, probs)
+        loss = tf.losses.sparse_categorical_crossentropy(target, probs)
 
     # BytePS: add bps Distributed GradientTape.
     tape = bps.DistributedGradientTape(tape, compression=compression)


### PR DESCRIPTION
There is a bug when I run the synthetic_benchmark_tf2.py.

The first parameter of [tf.losses.categorical_crossentropy](https://www.tensorflow.org/api_docs/python/tf/keras/losses/categorical_crossentropy) should be a tensor of one-hot true targets, but the parameter in this code is just integer. So, we should use [sparse_categorical_crossentropy](https://www.tensorflow.org/api_docs/python/tf/keras/losses/sparse_categorical_crossentropy).

I have fixed this bug.