### PR TITLE
packaging: ignore temp build directories

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,6 @@ include */* LICENSE byteps.lds byteps.exp
 exclude .git/*
 recursive-include * *.cc *.h
 graft 3rdparty/ps-lite
+prune 3rdparty/ps-lite/build
+prune 3rdparty/ps-lite/deps
 include ./pre_setup.py

--- a/setup.py
+++ b/setup.py
@@ -969,6 +969,9 @@ class custom_build_ext(build_ext):
 
 
 # Where the magic happens:
+if not os.path.exists('3rdparty/ps-lite/src'):
+    msg = "Missing ./3rdparty/ps-lite, ps-lite is required to build BytePS."
+    raise ValueError(msg)
 
 if os.path.exists('launcher/launch.py'):
     if not os.path.exists('bin'):


### PR DESCRIPTION
ignore temporary build directories in packaging.

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>