### PR TITLE
fix bug in tensorflow.push_pull

### DIFF
--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -63,7 +63,7 @@ def push_pull(tensor, scope='', average=None, device_dense='', device_sparse='',
         A tensor of the same shape and type as `tensor`, summed across all
         processes.
     """
-    op = handle_average_backwards_compatibility(op, average)
+    op = handle_average_backwards_compatibility(op, average).value
     # Averaging happens in framework code, so translate that to Sum for the actual call
     true_op = Sum if op == Average else op
 


### PR DESCRIPTION
In `tensorflow.push_pull` function, `op` is a `enum` type while `Average` is a str type, which means they can never equal. Now `tensorflow.push_pull` can only give SUM of tensors instead of AVERAGE. This pull request fix the bug.

See https://github.com/bytedance/byteps/issues/323