### PR TITLE
torch: fix the mnist example in torch

### DIFF
--- a/example/pytorch/train_mnist_byteps.py
+++ b/example/pytorch/train_mnist_byteps.py
@@ -130,6 +130,8 @@ def train(epoch):
 
 def metric_average(val, name):
     tensor = torch.tensor(val)
+    if args.cuda:
+        tensor = tensor.cuda()
     avg_tensor = bps.push_pull(tensor, name=name)
     return avg_tensor.item()
 


### PR DESCRIPTION
fix the train_mnist_byteps.py example in torch

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>