### PR TITLE
torch: use floor_divide_() for newer torch

### DIFF
--- a/byteps/torch/ops.cc
+++ b/byteps/torch/ops.cc
@@ -79,10 +79,12 @@ void StartTask(::torch::Tensor tensor, ::torch::Tensor output, int average,
         // Will execute in the `device` context.
         if (average) {
 #if TORCH_VERSION >= 1005000000
-          output.true_divide(byteps_size());
-#else
-          output.div_(byteps_size());
+          if (isIntegralType(output.scalar_type())) {
+            output.floor_divide_(byteps_size());
+            return;
+          }
 #endif
+          output.div_(byteps_size());
         }
         handle_manager.MarkDone(handle, status);
       },


### PR DESCRIPTION
use floor_divide_() to compute average in newer torch.

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>