### PR TITLE
torch: fix hang after int tensor push_pull

### DIFF
--- a/byteps/torch/ops.cc
+++ b/byteps/torch/ops.cc
@@ -81,6 +81,7 @@ void StartTask(::torch::Tensor tensor, ::torch::Tensor output, int average,
 #if TORCH_VERSION >= 1005000000
           if (isIntegralType(output.scalar_type())) {
             output.floor_divide_(byteps_size());
+            handle_manager.MarkDone(handle, status);
             return;
           }
 #endif


### PR DESCRIPTION
mark task done after averaging an int tensor. This fixes a bug
introduced in 46944e8.

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>