### PR TITLE
torch.autograd.profiler.profile() keyword argument

### DIFF
--- a/example/pytorch/benchmark_byteps.py
+++ b/example/pytorch/benchmark_byteps.py
@@ -114,7 +114,7 @@ log('Running benchmark...')
 img_secs = []
 enable_profiling = args.profiler & (bps.rank() == 0)
 
-with torch.autograd.profiler.profile(enable_profiling, True) as prof:
+with torch.autograd.profiler.profile(enabled=enable_profiling, use_cuda=True) as prof:
     for x in range(args.num_iters):
         time = timeit.timeit(benchmark_step, number=args.num_batches_per_iter)
         img_sec = args.batch_size * args.num_batches_per_iter / time


### PR DESCRIPTION
torch.autograd.profiler.profile() will not take 3 positional argumens (self, False, True) when enabled=False with the latest change to PyTorch source code.
This means that:
bpslaunch python benchmark_byteps.py --fp16-pushpull
fails with:
with torch.autograd.profiler.profile(False, True) as prof:                                                                               
TypeError: __init__() takes from 1 to 2 positional arguments but 3 were given
To fix this:
Use keyword arguments (enabled=enable_profiling, use_cuda=True)