### PR TITLE
tf: fix case in register gradient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,7 @@ script:
   - export DMLC_NODE_HOST=127.0.0.1
   - export PORT=8000
   - 3rdparty/ps-lite/tests/local.sh 1 1 3rdparty/ps-lite/tests/test_benchmark 1024000 10 0
+  - export PORT=8001
   - 3rdparty/ps-lite/tests/local.sh 2 2 3rdparty/ps-lite/tests/test_benchmark 1024000 10 0
+  - export PORT=8002
   - 3rdparty/ps-lite/tests/local.sh 4 4 3rdparty/ps-lite/tests/test_benchmark 1024000 10 0

--- a/byteps/tensorflow/ops.py
+++ b/byteps/tensorflow/ops.py
@@ -134,7 +134,7 @@ def _push_pull(tensor, scope='', name=None):
     return C_LIB.byteps_push_pull(tensor, name=name, input_name = full_name)
 
 
-@ops.RegisterGradient('BytePSPushPull')
+@ops.RegisterGradient('BytepsPushPull')
 def _push_pull_grad(op, grad):
     """Gradient for push_pull op.
     Args:
@@ -190,7 +190,7 @@ def broadcast(tensor, root_rank, scope='', name=None, is_variable=True):
         return C_LIB.byteps_push_pull(tensor, name=name, input_name = full_name)
 
 
-@ops.RegisterGradient('BytePSBroadcast')
+@ops.RegisterGradient('BytepsBroadcast')
 def _broadcast_grad(op, grad):
     """Gradient for broadcast op.
     Args:


### PR DESCRIPTION
register gradient operation for "BytepsPushPull" instead of
"BytePSPushPull". This matches the case in REGISTER_OP. Fixes the
following error:

  LookupError: gradient registry has no entry for: BytepsPushPull

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>