### PR TITLE
example: fix import for python3.8

### DIFF
--- a/example/pytorch/mnist-distributed.py
+++ b/example/pytorch/mnist-distributed.py
@@ -7,7 +7,7 @@ import torchvision.transforms as transforms
 import torch
 import torch.nn as nn
 import torch.distributed as dist
-from nn.parallel import DistributedDataParallel as DDP
+from torch.nn.parallel import DistributedDataParallel as DDP
 
 
 def main():


### PR DESCRIPTION
fix the import statement in pytorch/mnist-distributed.py for python 3.8

fixes https://github.com/bytedance/byteps/issues/376

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>