### PR TITLE
fix bool env, disable avx512

### DIFF
--- a/byteps/server/server.cc
+++ b/byteps/server/server.cc
@@ -406,20 +406,20 @@ void BytePSHandler(const ps::KVMeta& req_meta,
 
 void init_global_env() {
   // enable to print key profile
-  log_key_info_ = GetEnv("PS_KEY_LOG", false);
+  log_key_info_ = GetEnv("PS_KEY_LOG", 0);
 
   // enable engine block mode (default disabled)
-  is_engine_blocking_ = GetEnv("BYTEPS_SERVER_ENGINE_BLOCKING", false);
+  is_engine_blocking_ = GetEnv("BYTEPS_SERVER_ENGINE_BLOCKING", 0);
   if (is_engine_blocking_)
     LOG(INFO) << "Enable blocking mode of the server engine";
 
   // sync or async training
-  sync_mode_ = !GetEnv("BYTEPS_ENABLE_ASYNC", false);
+  sync_mode_ = !GetEnv("BYTEPS_ENABLE_ASYNC", 0);
   if (!sync_mode_)
     LOG(INFO) << "BytePS server is enabled asynchronous training";
 
   // debug mode
-  debug_mode_ = GetEnv("BYTEPS_SERVER_DEBUG", false);
+  debug_mode_ = GetEnv("BYTEPS_SERVER_DEBUG", 0);
   debug_key_ = GetEnv("BYTEPS_SERVER_DEBUG_KEY", 0);
   if (debug_mode_)
     LOG(INFO) << "Debug mode enabled! Printing key " << debug_key_;
@@ -433,7 +433,7 @@ void init_global_env() {
   CHECK_GE(engine_thread_num_, 1);
 
   // enable scheduling for server engine
-  enable_schedule_ = GetEnv("BYTEPS_SERVER_ENABLE_SCHEDULE", false);
+  enable_schedule_ = GetEnv("BYTEPS_SERVER_ENABLE_SCHEDULE", 0);
   if (enable_schedule_)
     LOG(INFO) << "Enable engine scheduling for BytePS server";
 }

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ def get_mpi_flags():
 
 def get_cpp_flags(build_ext):
     last_err = None
-    default_flags = ['-std=c++11', '-fPIC', '-Ofast', '-Wall', '-fopenmp', '-march=native']
+    default_flags = ['-std=c++11', '-fPIC', '-Ofast', '-Wall', '-fopenmp', '-march=native', '-mno-avx512f']
     flags_to_try = []
     if sys.platform == 'darwin':
         # Darwin most likely will have Clang, which has libc++.


### PR DESCRIPTION
- fix bool env parsing in server.cc
- disable avx512 when compiling. enabling avx512 may cause tensorflow
extension build failure. avx512 support in Eigen is likely not stable
yet.

Signed-off-by: yulu.jia <yulu.jia@bytedance.com>