### PR TITLE
TensorFlow 2.4+ compatibility

### DIFF
--- a/example/tensorflow/tensorflow2_keras_mnist.py
+++ b/example/tensorflow/tensorflow2_keras_mnist.py
@@ -61,8 +61,7 @@ opt = bps.DistributedOptimizer(opt)
 # uses bps.DistributedOptimizer() to compute gradients.
 mnist_model.compile(loss=tf.losses.SparseCategoricalCrossentropy(),
                     optimizer=opt,
-                    metrics=['accuracy'],
-                    experimental_run_tf_function=False)
+                    metrics=['accuracy'])
 
 callbacks = [
     # byteps: broadcast initial variable states from rank 0 to all other processes.


### PR DESCRIPTION
Current TF binding is not compatible with TF 2.4+, reference: #401. This PR follows recent changes in [Horovod](https://github.com/horovod/horovod/blob/7b44897733e724ba2a077e3bb277bd481e5be006/horovod/_keras/__init__.py#L117) to update distributed optimizer code to be compatible.