### PR TITLE
tensorflow: fix bug in broadcast_variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,7 @@ venv.bak/
 # for development
 scripts/
 exps/
+
+# dependency tarballs
+ucx.tar.gz
+zeromq-4.1.4.tar.gz

--- a/byteps/tensorflow/__init__.py
+++ b/byteps/tensorflow/__init__.py
@@ -116,7 +116,7 @@ def broadcast_variables(variables, root_rank, scope=''):
         scope: the graph name scope
     """
     if size() <= 1:
-        return variables
+        return tf.group(*variables)
     _assign = tf.assign if hasattr(tf, 'assign') else tf.compat.v1.assign
     return tf.group(*[_assign(var, broadcast(var, root_rank, scope))
                       for var in variables])


### PR DESCRIPTION
When there's only one rank in total, broadcast_variables should still
return a tf operation.

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>